### PR TITLE
#159310368 Feature Delete a diary entry

### DIFF
--- a/server/test/entry.js
+++ b/server/test/entry.js
@@ -183,4 +183,32 @@ describe('Entries', () => {
         });
     });
   });
+
+  describe('DELETE /api/v1/entries/:id', () => {
+    it('Should not delete an entry returns status code 404', (done) => {
+      const id = 20;
+      chai.request(server)
+        .delete(`/api/v1/entries/${id}`)
+        .send({ token: tokenObjec.token })
+        .end((err, req) => {
+          req.should.have.status(404);
+          req.body.should.be.a('object');
+          req.body.should.have.property('message').eql('failed');
+          done(err);
+        });
+    });
+
+    it('Should delete an entry returns status code 200', (done) => {
+      const id = 1;
+      chai.request(server)
+        .delete(`/api/v1/entries/${id}`)
+        .send({ token: tokenObjec.token })
+        .end((err, req) => {
+          req.should.have.status(200);
+          req.body.should.be.a('object');
+          req.body.should.have.property('message').eql('success');
+          done(err);
+        });
+    });
+  });
 });


### PR DESCRIPTION
### What does this PR do?
This PR will add delete entry feature, with testing.

### Description of task to be completed ?
Implement the following:
Add testing for delete diary entry endpoint.
`delete()` method of entry Model should used database connection,
in helpers/dbHelpers.js to delete entry.

### How should this be tested ?
You should have PostgreSQL installed before you get started. Then clone this repo, run npm install to install all dependencies and devDependencis.
Open server/helpers/dbHelper.js change the connection string to match that of your local machine.
Then run `npm test` , and then `npm start-dev`
start POSTMAN
`POST /auth/login` , enter email as `test9@gmail.com`, password `test123`
then access `GET /api/v1/entries/:id` include token received from login response on the request header.


### What are the relevant pivotal tracker stories?
#159310368

### Any background context you wish to provide?
None